### PR TITLE
[draft] Use file extension to determine library type

### DIFF
--- a/TwinpackShared/Protocol/Nuget/NugetServer.cs
+++ b/TwinpackShared/Protocol/Nuget/NugetServer.cs
@@ -243,7 +243,7 @@ namespace Twinpack.Protocol
                         {
                             try
                             {
-                                var extension = library.EndsWith(".library") ? "compiled-library" : "library";
+                                var extension = library.EndsWith(".compiled-library") ? "compiled-library" : "library";
                                 var filePath = $@"{cachePath ?? DefaultLibraryCachePath}\{packageVersion.Target}";
                                 var fileName = $@"{filePath}\{packageVersion.Name}_{packageVersion.Version}.{extension}";
                                 Directory.CreateDirectory(filePath);

--- a/TwinpackShared/TwinpackUtils.cs
+++ b/TwinpackShared/TwinpackUtils.cs
@@ -294,13 +294,27 @@ namespace Twinpack
 
         public static void InstallPackageVersions(ITcPlcLibraryManager libManager, List<PackageVersionGetResponse> packageVersions, string cachePath = null)
         {
-
             foreach (var packageVersion in packageVersions)
             {
                 _logger.Info($"Installing {packageVersion.Name} {packageVersion.Version}");
 
-                var suffix = packageVersion.Compiled == 1 ? "compiled-library" : "library";
-                libManager.InstallLibrary("System", Path.GetFullPath($@"{cachePath ?? DefaultLibraryCachePath}\{packageVersion.Target}\{packageVersion.Name}_{packageVersion.Version}.{suffix}"), bOverwrite: true);
+                var path = Path.GetFullPath($@"{cachePath ?? DefaultLibraryCachePath}\{packageVersion.Target}\{packageVersion.Name}_{packageVersion.Version}");
+
+                if (File.Exists($@"{path}.library"))
+                {
+                    path = $@"{path}.library";
+                } 
+                else if (File.Exists($@"{path}.compiled-library"))
+                {
+                    path = $@"{path}.compiled-library";
+                }
+                else
+                {
+                    _logger.Warn($"Did not find library in {path} with either .library or .compiled-library extensions");
+                    return;
+                }
+
+                libManager.InstallLibrary("System", path, bOverwrite: true);
             }
         }
 


### PR DESCRIPTION
See https://github.com/Zeugwerk/Twinpack/issues/138

This is a work-around since the library type is not currently implemented in NugetServer. 

This PR is not complete because there are other places in the code that I did not change that still refer to the project configuration for the library type, such as https://github.com/Zeugwerk/Twinpack/blob/main/TwinpackShared/TwinpackUtils.cs#L558