### PR TITLE
fix: restore overwrites version: null with the current latest version

### DIFF
--- a/TwinpackCore/Configuration/Config.cs
+++ b/TwinpackCore/Configuration/Config.cs
@@ -70,7 +70,6 @@ namespace Twinpack.Configuration
             Target = pv.PackageVersion?.Target;
             Configuration = pv.PackageVersion?.Configuration;
 
-            Namespace = pv.Config?.Namespace;
             Parameters = pv.Config?.Parameters;
             Options = pv.Config?.Options;
         }
@@ -83,7 +82,6 @@ namespace Twinpack.Configuration
             Target = pv.Target;
             Configuration = pv.Configuration;
             DistributorName = pv.DistributorName;
-            Namespace = pv.Name;
             Parameters = null;
             Options = null;
         }
@@ -96,7 +94,6 @@ namespace Twinpack.Configuration
             Target = pv.Target;
             Configuration = pv.Configuration;
             DistributorName = pv.DistributorName;
-            Namespace = pv.Name;
             Parameters = pv.Parameters;
             Options = pv.Options;
         }
@@ -109,7 +106,6 @@ namespace Twinpack.Configuration
             Configuration = "Release";
             Version = null;
             DistributorName = null;
-            Namespace = null;
             Parameters = null;
             Options = null;
         }
@@ -141,11 +137,6 @@ namespace Twinpack.Configuration
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]        
         [JsonPropertyName("distributor-name")]
         public string DistributorName { get; set; }
-        
-        [DefaultValue(null)]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]        
-        [JsonPropertyName("namespace")]
-        public string Namespace { get; set; }
 
         [DefaultValue(null)]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/TwinpackCore/Core/TwinpackService.cs
+++ b/TwinpackCore/Core/TwinpackService.cs
@@ -626,7 +626,7 @@ namespace Twinpack.Core
                 // update configuration
                 var plcConfig = config?.Projects.FirstOrDefault(x => x.Name == package.ProjectName)?.Plcs?.FirstOrDefault(x => x.Name == package.PlcName);
                 var packageIndex = plcConfig?.Packages.FindIndex(x => x.Name == package.PackageVersion.Name);
-                var newPackageConfig = new ConfigPlcPackage(package.PackageVersion) { Options = package.Config.Options };
+                var newPackageConfig = new ConfigPlcPackage(package.PackageVersion) { Options = package.Config.Options, Version = package.Config.Version == null ? null : package.PackageVersion.Version };
 
                 package.Config = newPackageConfig;
                 addedPackages.Add(package);


### PR DESCRIPTION
This issue is only relevant for CLI, in the vsix the PackageVersion is known and PackageVersion.Version is explictly set to null before copying the infto to Config.Version